### PR TITLE
StepFunctions用のECRとECSのリソースを作成する

### DIFF
--- a/modules/aws/stepfunctions-sample/ecr/main.tf
+++ b/modules/aws/stepfunctions-sample/ecr/main.tf
@@ -1,0 +1,38 @@
+locals {
+  lifecycle_policy = <<EOF
+  {
+    "rules": [
+      {
+        "rulePriority": 10,
+        "description": "Expire images count more than 5",
+        "selection": {
+          "tagStatus": "any",
+          "countType": "imageCountMoreThan",
+          "countNumber": 5
+        },
+        "action": {
+          "type": "expire"
+        }
+      }
+    ]
+  }
+EOF
+}
+
+resource "aws_ecr_repository" "step_functions_sync" {
+  name = "${var.env}-stepfunctions-sync"
+}
+
+resource "aws_ecr_lifecycle_policy" "step_functions_sync" {
+  repository = aws_ecr_repository.step_functions_sync.name
+  policy = local.lifecycle_policy
+}
+
+resource "aws_ecr_repository" "step_functions_wait_token" {
+  name = "${var.env}-stepfunctions-wait-token"
+}
+
+resource "aws_ecr_lifecycle_policy" "step_functions_wait_token" {
+  repository = aws_ecr_repository.step_functions_wait_token.name
+  policy = local.lifecycle_policy
+}

--- a/modules/aws/stepfunctions-sample/ecr/variable.tf
+++ b/modules/aws/stepfunctions-sample/ecr/variable.tf
@@ -1,0 +1,1 @@
+variable "env" {}

--- a/modules/aws/stepfunctions-sample/ecs/ecs.tf
+++ b/modules/aws/stepfunctions-sample/ecs/ecs.tf
@@ -1,0 +1,7 @@
+resource "aws_ecs_cluster" "app" {
+  name = var.ecs_cluster_name
+}
+
+resource "aws_cloudwatch_log_group" "app" {
+  name = var.cloudwatch_logname
+}

--- a/modules/aws/stepfunctions-sample/ecs/iam.tf
+++ b/modules/aws/stepfunctions-sample/ecs/iam.tf
@@ -1,0 +1,65 @@
+// for TaskRole
+data "aws_iam_policy_document" "task_role_trust_relationship" {
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "task_role" {
+  name               = "${var.role}-task-role"
+  assume_role_policy = data.aws_iam_policy_document.task_role_trust_relationship.json
+}
+
+resource "aws_iam_role_policy" "task_role_step_functions" {
+  name = "step-functions-policy"
+  role = aws_iam_role.task_role.id
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": [
+            "states:SendTaskSuccess",
+            "states:SendTaskFailure",
+            "states:SendTaskHeartbeat"
+          ],
+          "Resource": "*"
+        }
+    ]
+}
+EOF
+}
+
+// for ExecutionTaskRole
+data "aws_iam_policy_document" "task_execution_trust_relationship" {
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "task_execution_role" {
+  name = "${var.role}-task-execution-role"
+  assume_role_policy = data.aws_iam_policy_document.task_execution_trust_relationship.json
+}
+
+resource "aws_iam_role_policy_attachment" "task_execution_role_attach" {
+  role = aws_iam_role.task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+

--- a/modules/aws/stepfunctions-sample/ecs/sg.tf
+++ b/modules/aws/stepfunctions-sample/ecs/sg.tf
@@ -1,0 +1,18 @@
+resource "aws_security_group" "ecs" {
+  name        = var.ecs_sg_name
+  description = var.ecs_sg_name
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name = var.ecs_sg_name
+  }
+}
+
+resource "aws_security_group_rule" "ecs_egress" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.ecs.id
+}

--- a/modules/aws/stepfunctions-sample/ecs/variable.tf
+++ b/modules/aws/stepfunctions-sample/ecs/variable.tf
@@ -1,0 +1,7 @@
+variable "env" {}
+variable "role" {}
+variable "vpc_id" {}
+
+variable "ecs_cluster_name" {}
+variable "cloudwatch_logname" {}
+variable "ecs_sg_name" {}

--- a/modules/aws/stepfunctions-sample/iam/main.tf
+++ b/modules/aws/stepfunctions-sample/iam/main.tf
@@ -1,0 +1,95 @@
+// for stepfunctions (sync)
+data "aws_iam_policy_document" "step_functions_sync_role_trust_relationship" {
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["states.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "step_functions_sync_role" {
+  name               = "${var.role}-stepfunctions-sync-role"
+  assume_role_policy = data.aws_iam_policy_document.step_functions_sync_role_trust_relationship.json
+}
+
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+resource "aws_iam_role_policy" "step_functions_sync_policy" {
+  name = "stepfunctions-sync-policy"
+  role = aws_iam_role.step_functions_sync_role.id
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ecs:RunTask",
+                "ecs:StopTask",
+                "ecs:DescribeTasks",
+                "iam:PassRole"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "events:PutTargets",
+                "events:PutRule",
+                "events:DescribeRule"
+            ],
+            "Resource": [
+               "arn:aws:events:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rule/StepFunctionsGetEventsForECSTaskRule"
+            ]
+        }
+    ]
+}
+EOF
+}
+
+// for stepfunctions (waitForTaskToken)
+data "aws_iam_policy_document" "step_functions_wait_role_trust_relationship" {
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type = "Service"
+      identifiers = ["states.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "step_functions_wait_role" {
+  name = "${var.role}-stepfunctions-wait-role"
+  assume_role_policy = data.aws_iam_policy_document.step_functions_wait_role_trust_relationship.json
+}
+
+resource "aws_iam_role_policy" "step_functions_wait_policy" {
+  name = "stepfunctions-wait-policy"
+  role = aws_iam_role.step_functions_wait_role.id
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": [
+            "ecs:RunTask",
+            "iam:PassRole"
+          ],
+          "Resource": "*"
+        }
+    ]
+}
+EOF
+}

--- a/modules/aws/stepfunctions-sample/iam/variable.tf
+++ b/modules/aws/stepfunctions-sample/iam/variable.tf
@@ -1,0 +1,2 @@
+variable "role" {}
+

--- a/modules/aws/vpc/nat-gatway.tf
+++ b/modules/aws/vpc/nat-gatway.tf
@@ -9,11 +9,9 @@ resource "aws_eip" "nat" {
 
 resource "aws_nat_gateway" "nat" {
   count         = 2
-  subnet_id     = aws_subnet.private_subnet[count.index].id
+  subnet_id     = aws_subnet.public_subnet[count.index].id
   allocation_id = aws_eip.nat[count.index].id
 }
-
-
 
 resource "aws_route_table" "private" {
   count  = 2

--- a/providers/aws/dev/stepfunctions-sample/backend.tf
+++ b/providers/aws/dev/stepfunctions-sample/backend.tf
@@ -6,3 +6,14 @@ terraform {
     profile = "kobayashi-m42-dev"
   }
 }
+
+data "terraform_remote_state" "network" {
+  backend = "s3"
+
+  config = {
+    bucket  = "kobayashi-m42-tfstate"
+    key     = "vpc/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "kobayashi-m42-dev"
+  }
+}

--- a/providers/aws/dev/stepfunctions-sample/backend.tf
+++ b/providers/aws/dev/stepfunctions-sample/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "kobayashi-m42-tfstate"
+    key     = "stepfunctions-sample/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "kobayashi-m42-dev"
+  }
+}

--- a/providers/aws/dev/stepfunctions-sample/main.tf
+++ b/providers/aws/dev/stepfunctions-sample/main.tf
@@ -1,0 +1,5 @@
+module "vpc" {
+  source = "../../../../modules/aws/stepfunctions-sample/ecr"
+
+  env = local.env
+}

--- a/providers/aws/dev/stepfunctions-sample/main.tf
+++ b/providers/aws/dev/stepfunctions-sample/main.tf
@@ -1,5 +1,16 @@
-module "vpc" {
+module "ecr" {
   source = "../../../../modules/aws/stepfunctions-sample/ecr"
 
   env = local.env
+}
+
+module "ecs" {
+  source = "../../../../modules/aws/stepfunctions-sample/ecs"
+
+  env                = local.env
+  role               = local.role
+  vpc_id             = data.terraform_remote_state.network.outputs.vpc_id
+  ecs_cluster_name   = local.ecs_cluster_name
+  cloudwatch_logname = local.cloudwatch_logname
+  ecs_sg_name        = local.ecs_sg_name
 }

--- a/providers/aws/dev/stepfunctions-sample/main.tf
+++ b/providers/aws/dev/stepfunctions-sample/main.tf
@@ -14,3 +14,9 @@ module "ecs" {
   cloudwatch_logname = local.cloudwatch_logname
   ecs_sg_name        = local.ecs_sg_name
 }
+
+module "iam" {
+  source = "../../../../modules/aws/stepfunctions-sample/iam"
+
+  role = local.role
+}

--- a/providers/aws/dev/stepfunctions-sample/provider.tf
+++ b/providers/aws/dev/stepfunctions-sample/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  version = "=2.51.0"
+  region  = "ap-northeast-1"
+}

--- a/providers/aws/dev/stepfunctions-sample/variable.tf
+++ b/providers/aws/dev/stepfunctions-sample/variable.tf
@@ -1,0 +1,3 @@
+locals {
+  env = "dev"
+}

--- a/providers/aws/dev/stepfunctions-sample/variable.tf
+++ b/providers/aws/dev/stepfunctions-sample/variable.tf
@@ -1,3 +1,7 @@
 locals {
-  env = "dev"
+  env                = "dev"
+  role               = "stepfunctions-sample"
+  ecs_cluster_name   = "${local.env}-${local.role}"
+  ecs_sg_name        = "${local.env}-${local.role}"
+  cloudwatch_logname = "${local.env}-${local.role}"
 }

--- a/providers/aws/dev/stepfunctions-sample/versions.tf
+++ b/providers/aws/dev/stepfunctions-sample/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = "=0.12.21"
+}


### PR DESCRIPTION
StepFuntcionsを利用してFargateのタスクを起動するために必要なリソースを作成。

また、Issueとは関係ないがNATゲートウェイの常駐先サブネットをパブリックに修正。
プライベートサブネットが指定されておりECRからイメージをpullする際にエラーとなっていた。
